### PR TITLE
alioth: change status bar padding

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -31,7 +31,7 @@
     <dimen name="status_bar_padding_start">15dp</dimen>
 
     <!-- the padding on the end of the statusbar -->
-    <dimen name="status_bar_padding_end">18dp</dimen>
+    <dimen name="status_bar_padding_end">15dp</dimen>
 
     <!-- the padding on the end of the keyguard statusbar -->
     <dimen name="system_icons_keyguard_padding_end">15dp</dimen>


### PR DESCRIPTION
Alioth is using a center punch hole, current padding left and right are have differences. Change padding end to same value padding start.